### PR TITLE
Allow certificate customization via environment variables

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -20,6 +20,7 @@ if ! test -e ${TASKDDATA}/config; then
   cp /usr/share/taskd/pki/generate* ${TASKDDATA}/pki
   cp /usr/share/taskd/pki/vars ${TASKDDATA}/pki
   cd ${TASKDDATA}/pki
+  sed -i 's/\(.*\)=\(.*\)/\1=${CERT_\1:-\2}/' vars
   ./generate
   cd /
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,37 @@ docker run -d \
 This makes a set of self signed certificates and minimal configuration to
 run server.
 
-The certificate attributes may be customized via environment variables:
-- CERT_BITS=4096
-- CERT_EXPIRATION_DAYS=365
-- CERT_ORGANIZATION="Göteborg Bit Factory"
-- CERT_CN=localhost
-- CERT_COUNTRY=SE
-- CERT_STATE="Västra Götaland"
-- CERT_LOCALITY="Göteborg"
+## Environment variables
+
+Certificate attributes can be customized using environment variables.
+
+| Variable | Default value |
+| --- | --- |
+| `CERT_BITS` | 4096 |
+| `CERT_EXPIRATION_DAYS` | 365 |
+| `CERT_ORGANIZATION` | "Göteborg Bit Factory" |
+| `CERT_CN` | localhost |
+| `CERT_COUNTRY` | SE |
+| `CERT_STATE` | "Västra Götaland" |
+| `CERT_LOCALITY` | "Göteborg" |
+
+Note that, by default, the generated certificates will have their `CN` set
+to `localhost`.
+
+To regenerate certificates or modify their parameters:
+- Delete everything in `/pki/` except the generate scripts (`generate*`) and the `vars` file.
+- Run (modify the variables to what you need)
+  ```sh
+  docker exec -t -i \
+    -e CERT_BITS=4096 \
+    -e CERT_EXPIRATION_DAYS=365 \
+    -e CERT_ORGANIZATION="Göteborg Bit Factory" \
+    -e CERT_CN=localhost \
+    -e CERT_COUNTRY=SE \
+    -e CERT_STATE="Västra Götaland" \
+    -e CERT_LOCALITY="Göteborg" \
+    <container-id> /var/taskd/pki/generate
+  ```
 
 ## Manual setup
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ docker run -d \
 This makes a set of self signed certificates and minimal configuration to
 run server.
 
-Please note that the generated certificated will have their `CN` set to `localhost`. In order to modify the parameters used for the certificate generation:
-- Delete everything in `/pki/` except the generate scripts (`generate*`) and the `vars` file.
-- Edit the `vars` file.
-- Run `docker exec -it <container-id> /var/taskd/pki/generate`.
+The certificate attributes may be customized via environment variables:
+- CERT_BITS=4096
+- CERT_EXPIRATION_DAYS=365
+- CERT_ORGANIZATION="Göteborg Bit Factory"
+- CERT_CN=localhost
+- CERT_COUNTRY=SE
+- CERT_STATE="Västra Götaland"
+- CERT_LOCALITY="Göteborg"
 
 ## Manual setup
 
@@ -47,7 +51,7 @@ in data volume `/var/taskd`. If found it, simply run the server, but if
 config file is absent `run.sh` will build a new default config and its
 certificates.
 
-If you make the data volume permanent you'll can access to its contents and
+If you make the data volume permanent you can access to its contents and
 make modifications that you need. The significant files are.
 
 * `config` taskd config itself.


### PR DESCRIPTION
As the title says, this pull request allows customizing the certificate generation by specifying environment variables `CERT_CN`, `CERT_COUNTRY`, etc.
These variables are derived by prefixing the variables specified in `vars` with `CERT`.

This is common behavior in docker images and enables configuration via `docker-compose.yml` or `docker run --env ...`

Customization is implemented by replacing all lines in `vars` like this:
`CN=localhost` -> `CN=${CERT_CN:-localhost}`
That way, all default values in `vars` are preserved and if any options are added in the future, they will automatically have the corresponding environment variables.